### PR TITLE
[#23] - 유저의 전체랭킹 조회 기능 구현

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/account/entity/Account.java
+++ b/src/main/java/com/sascom/chickenstock/domain/account/entity/Account.java
@@ -46,7 +46,14 @@ public class Account extends BaseTimeEntity {
     @Column(name = "rating_change")
     private Integer ratingChange;
 
-
+    public void updateRankingAndRatingChange(int ranking, int ratingChange) {
+        if(ranking <= 0) {
+            throw new IllegalArgumentException("ranking should be greater than 0");
+        }
+        this.ranking = ranking;
+        this.ratingChange = ratingChange;
+        return;
+    }
 
     public Account(Member member, Competition competition) {
         this.member = member;

--- a/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
@@ -1,11 +1,26 @@
 package com.sascom.chickenstock.domain.member.repository;
 
 import com.sascom.chickenstock.domain.member.entity.Member;
+import com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findFirst10ByNicknameStartingWithOrderByNickname(String prefix);
+
+    @Query(value = "SELECT " +
+            "member.member_id AS member_id, " +
+            "member.nickname AS nickname, " +
+            "SUM(account.balance) AS profit, " +
+            "SUM(account.rating_change) AS rating, " +
+            "COUNT(account.account_id) AS competition_count," +
+            "RANK() OVER (ORDER BY SUM(account.rating_change) DESC) AS ranking " +
+            "FROM member " +
+            "JOIN account ON member.member_id = account.member_id " +
+            "LIMIT :offset, 10",
+            nativeQuery = true)
+    List<MemberRankingDto> test(@Param("offset") int offset);
 }

--- a/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
@@ -12,11 +12,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findFirst10ByNicknameStartingWithOrderByNickname(String prefix);
 
     @Query(value = "SELECT " +
-            "member.member_id AS member_id, " +
+            "member.member_id AS memberId, " +
             "member.nickname AS nickname, " +
             "SUM(account.balance) AS profit, " +
             "SUM(account.rating_change) AS rating, " +
-            "COUNT(account.account_id) AS competition_count," +
+            "COUNT(account.account_id) AS competitionCount," +
             "RANK() OVER (ORDER BY SUM(account.rating_change) DESC) AS ranking " +
             "FROM member " +
             "JOIN account ON member.member_id = account.member_id " +

--- a/src/main/java/com/sascom/chickenstock/domain/member/service/MemberService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.sascom.chickenstock.domain.member.dto.response.MemberInfoResponse;
 import com.sascom.chickenstock.domain.member.dto.response.PrefixNicknameInfosResponse;
 import com.sascom.chickenstock.domain.member.entity.Member;
 import com.sascom.chickenstock.domain.member.repository.MemberRepository;
+import com.sascom.chickenstock.domain.ranking.util.RatingCalculatorV1;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -81,20 +82,8 @@ public class MemberService {
         return new MemberInfoResponse(
                 member.getId(),
                 member.getNickname(),
-                calculateLatestRating(member),
+                RatingCalculatorV1.calculateRating(member.getAccounts()),
                 member.getPoint());
-    }
-
-    private int calculateLatestRating(Member member) {
-        // find latest competition and latest rating from account.
-        // this implementation may occur 1 + N problem.
-        int latestRating = 0;
-        for(Account account : member.getAccounts()) {
-            if(account.getRatingChange() != null) {
-                latestRating += account.getRatingChange();
-            }
-        }
-        return latestRating;
     }
 
     // check that given new password is fit to safe password standard.

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
@@ -1,10 +1,52 @@
 package com.sascom.chickenstock.domain.ranking.controller;
 
+import com.sascom.chickenstock.domain.ranking.dto.response.RankingListResponse;
+import com.sascom.chickenstock.domain.ranking.service.RankingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/ranking")
 public class RankingController {
 
+    private final RankingService rankingService;
+
+    @Autowired
+    public RankingController(RankingService rankingService) {
+        this.rankingService = rankingService;
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<RankingListResponse> getAllRankingByOffset(
+            @RequestParam(name = "offset") Integer offset
+    ) {
+        if(offset == null) {
+            offset = 0;
+        }
+        if(offset < 0) {
+            // TODO: IllegalArgumentException -> Custom Exception
+            throw new IllegalArgumentException("offset must be greater than zero");
+        }
+
+        return ResponseEntity.ok().body(null);
+    }
+
+    @GetMapping("/rival")
+    public ResponseEntity<RankingListResponse> getRivalRankingByOffset(
+            @RequestParam(name = "offset") Integer offset
+    ) {
+        if(offset == null) {
+            offset = 0;
+        }
+        if(offset < 0) {
+            // TODO: IllegalArgumentException -> Custom Exception
+            throw new IllegalArgumentException("offset must be greater than zero");
+        }
+
+        return ResponseEntity.ok().body(null);
+    }
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
@@ -25,14 +25,14 @@ public class RankingController {
             @RequestParam(name = "offset") Integer offset
     ) {
         if(offset == null) {
-            offset = 0;
+            offset = 1;
         }
-        if(offset < 0) {
+        if(isValidOffset(offset)) {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }
-
-        return ResponseEntity.ok().body(null);
+        RankingListResponse rankingListResponse = rankingService.lookUpPaginationRanking(offset);
+        return ResponseEntity.ok().body(rankingListResponse);
     }
 
     @GetMapping("/rival")
@@ -42,11 +42,15 @@ public class RankingController {
         if(offset == null) {
             offset = 0;
         }
-        if(offset < 0) {
+        if(isValidOffset(offset)) {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }
 
         return ResponseEntity.ok().body(null);
+    }
+
+    private boolean isValidOffset(Integer offset) {
+        return offset != null && offset > 0;
     }
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
@@ -1,0 +1,10 @@
+package com.sascom.chickenstock.domain.ranking.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ranking")
+public class RankingController {
+
+}

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
@@ -27,7 +27,7 @@ public class RankingController {
         if(offset == null) {
             offset = 1;
         }
-        if(isValidOffset(offset)) {
+        if(!isValidOffset(offset)) {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }
@@ -42,7 +42,7 @@ public class RankingController {
         if(offset == null) {
             offset = 0;
         }
-        if(isValidOffset(offset)) {
+        if(!isValidOffset(offset)) {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
@@ -1,0 +1,15 @@
+package com.sascom.chickenstock.domain.ranking.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public record MemberRankingDto(
+        Long memberId,
+        Integer rank,
+        String nickname,
+        Long sum,
+        Integer rating,
+        Integer competitionCount
+) { }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
@@ -1,15 +1,10 @@
 package com.sascom.chickenstock.domain.ranking.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public record MemberRankingDto(
-        Long memberId,
-        Integer rank,
-        String nickname,
-        Long sum,
-        Integer rating,
-        Integer competitionCount
-) { }
+public interface MemberRankingDto {
+    Long getMemberId();
+    Integer getRanking();
+    String getNickname();
+    Long getProfit();
+    Integer getRating();
+    Integer getCompetitionCount();
+}

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/response/RankingListResponse.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/response/RankingListResponse.java
@@ -1,9 +1,10 @@
 package com.sascom.chickenstock.domain.ranking.dto.response;
 
 import com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
-@Getter
+@Builder
 public record RankingListResponse(List<MemberRankingDto> memberList) { }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/response/RankingListResponse.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/response/RankingListResponse.java
@@ -1,0 +1,9 @@
+package com.sascom.chickenstock.domain.ranking.dto.response;
+
+import com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public record RankingListResponse(List<MemberRankingDto> memberList) { }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
@@ -15,6 +15,8 @@ import java.util.List;
 @Service
 public class RankingService {
     // 분명 rival 랭킹과 전체 랭킹을 한 번에 처리할 수 있게 짤 수 있을 거 같다...
+    // + 전체 유저가 적은데 저걸 매번 DB에서 복잡한 쿼리를 날려서 받아올게 아니라 여기에 List 형태로
+    //   memoryRepository로 저장해두고 대회 끝날 때 마다 레이팅 계산하고 update 하면 되지 않나...?
     private final MemberRepository memberRepository;
 
     @Autowired

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
@@ -1,0 +1,7 @@
+package com.sascom.chickenstock.domain.ranking.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class RankingService {
+}

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
@@ -1,7 +1,32 @@
 package com.sascom.chickenstock.domain.ranking.service;
 
+import com.sascom.chickenstock.domain.account.repository.AccountRepository;
+import com.sascom.chickenstock.domain.member.entity.Member;
+import com.sascom.chickenstock.domain.member.repository.MemberRepository;
+import com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto;
+import com.sascom.chickenstock.domain.ranking.dto.response.RankingListResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class RankingService {
+    // 분명 rival 랭킹과 전체 랭킹을 한 번에 처리할 수 있게 짤 수 있을 거 같다...
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public RankingService(MemberRepository memberRepository, AccountRepository accountRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public RankingListResponse lookUpPaginationRanking(int offset) {
+        List<MemberRankingDto> result = memberRepository.test((offset - 1) * 10);
+        return RankingListResponse.builder()
+                .memberList(result)
+                .build();
+    }
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
@@ -13,7 +13,7 @@ public class RatingCalculatorV1 {
     private final int RATING_LOWER_BOUND = 0;
     private final int RATING_UPPER_BOUND = 5000;
 
-    public int calculateRating(List<Account> accounts) {
+    public static int calculateRating(List<Account> accounts) {
         if(accounts == null || accounts.isEmpty()){
             return INITIAL_RATING;
         }
@@ -37,7 +37,6 @@ public class RatingCalculatorV1 {
         // calculate rank of competition.
         // time complexity: O(N log N)
         Collections.sort(participants, (lhs, rhs) -> Long.compare(rhs.account.getBalance(), lhs.account.getBalance()));
-        participants.get(0).ranking = 1;
         for(int i = 0, j = 0; i < participants.size(); i = j) {
             while(j < participants.size() && participants.get(j).ranking == participants.get(i).ranking) {
                 participants.get(j).expectedRanking = 1.0;
@@ -78,7 +77,7 @@ public class RatingCalculatorV1 {
         return resultList;
     }
 
-    // find the performanceRating to receive the expectedRanking in this competition
+    // find the performanceRating to receive the expectedRanking in this competition.
     // time complexity: O(N log (RATING_UPPER_BOUND - RATING_LOWER_BOUND))
     private int getPerformanceRating(Participant participant, List<Participant> participants) {
         int left = RATING_LOWER_BOUND, right = RATING_UPPER_BOUND;

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
@@ -1,0 +1,123 @@
+package com.sascom.chickenstock.domain.ranking.util;
+
+import com.sascom.chickenstock.domain.account.entity.Account;
+
+import java.util.*;
+
+/*
+reference: [Codeforces Rating System](https://codeforces.com/blog/entry/20762)
+ */
+public class RatingCalculatorV1 {
+
+    static final int INITIAL_RATING = 1200;
+    private final int RATING_LOWER_BOUND = 0;
+    private final int RATING_UPPER_BOUND = 5000;
+
+    public int calculateRating(List<Account> accounts) {
+        if(accounts == null || accounts.isEmpty()){
+            return INITIAL_RATING;
+        }
+        int rating = INITIAL_RATING;
+        for (Account account : accounts) {
+            rating += account.getRatingChange();
+        }
+        return rating;
+    }
+
+    public List<Account> processCompetitionResult(Map<Account, Integer> accountBeforeRatingMap) {
+        // accountRatingMap
+        //      keys  : accounts of competition
+        //      values: rating before competition
+        List<Participant> participants = accountBeforeRatingMap
+                .entrySet()
+                .stream()
+                .map(entry -> new Participant(entry.getKey(), entry.getValue()))
+                .toList();
+
+        // calculate rank of competition.
+        // time complexity: O(N log N)
+        Collections.sort(participants, (lhs, rhs) -> Long.compare(rhs.account.getBalance(), lhs.account.getBalance()));
+        participants.get(0).ranking = 1;
+        for(int i = 0, j = 0; i < participants.size(); i = j) {
+            while(j < participants.size() && participants.get(j).ranking == participants.get(i).ranking) {
+                participants.get(j).expectedRanking = 1.0;
+                participants.get(j++).ranking = i + 1;
+            }
+        }
+
+        // expectedRanking_i = 1.0 + \sum_{j != i} eloWinProbability(ratingJ, ratingI)
+        // why add 1.0? -> our ranking system is 1-based.
+        // time complexity: O(N^2)
+        for(int i = 0; i < participants.size() - 1; i++) {
+            for(int j = i + 1; j < participants.size(); j++) {
+                Participant participantI = participants.get(i),
+                        participantJ = participants.get(j);
+                participantI.expectedRanking +=
+                        eloWinProbability(participantJ.beforeRating, participantI.beforeRating);
+                participantJ.expectedRanking +=
+                        eloWinProbability(participantI.beforeRating, participantJ.beforeRating);
+            }
+        }
+
+
+        // ratingChange <- (performanceRating - beforeRating) / 2: this rating change formula can be modified.
+        // time complexity: O(N^2 log (RATING_UPPER_BOUND - RATING_LOWER_BOUND))
+        for(Participant participant : participants) {
+            int left = getPerformanceRating(participant, participants);
+            participant.ratingChange = (left - participant.beforeRating) / 2;
+        }
+
+        List<Account> resultList = new ArrayList<>(accountBeforeRatingMap.size());
+        participants.forEach(participant -> {
+            participant.account.updateRankingAndRatingChange(
+                    participant.ranking,
+                    participant.ratingChange
+            );
+            resultList.add(participant.account);
+        });
+        return resultList;
+    }
+
+    // find the performanceRating to receive the expectedRanking in this competition
+    // time complexity: O(N log (RATING_UPPER_BOUND - RATING_LOWER_BOUND))
+    private int getPerformanceRating(Participant participant, List<Participant> participants) {
+        int left = RATING_LOWER_BOUND, right = RATING_UPPER_BOUND;
+        double expectedRanking = participant.expectedRanking;
+        while(right - left > 1) {
+            int mid = (left + right) / 2;
+            double midExpectedRanking = 1.0;
+            for(Participant otherParticipant : participants) {
+                midExpectedRanking += eloWinProbability(otherParticipant.beforeRating, mid);
+            }
+            if(midExpectedRanking >= expectedRanking) {
+                left = mid;
+            }
+            else {
+                right = mid;
+            }
+        }
+        return left;
+    }
+
+    /**
+     * calculate win probability of playerA against playerB in Elo rating system.
+     * @param ratingA - rating of playerA
+     * @param ratingB - rating of playerB
+     * @return win probability of playerA
+     */
+    private double eloWinProbability(int ratingA, int ratingB) {
+        return 1.0 / (1.0 + Math.pow(10.0, 1.0 * (ratingB - ratingA) / 400.0));
+    }
+
+    private static class Participant {
+        private final Account account;
+        private final int beforeRating;
+        private int ranking;
+        private double expectedRanking;
+        private int ratingChange;
+        private Participant(Account account, Integer beforeRating) {
+            this.account = account;
+            this.beforeRating = beforeRating;
+        }
+    }
+}


### PR DESCRIPTION
close #23 
-------------------------------------------
## 개요
랭킹 조회를 위해 전체 랭킹 조회 기능을 추가했습니다.
추가로 레이팅 계산(한 유저의 현재 레이팅 조회/대회 종료 후 유저들의 레이팅 변동 계산)을 위한 레이팅 계산기도 구현했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

!테스트 사진 첨부!
