### PR TITLE
[#37] rival 랭킹 조회 구현

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/repository/MemberRepository.java
@@ -23,4 +23,15 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "LIMIT :offset, 10",
             nativeQuery = true)
     List<MemberRankingDto> test(@Param("offset") int offset);
+
+    @Query("SELECT new com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto(" +
+            "m.id, " +
+            "m.nickname, " +
+            "SUM(a.balance), " +
+            "SUM(a.ratingChange), " +
+            "COUNT(a.id)) " +
+            "FROM Member m " +
+            "JOIN m.accounts a " +
+            "GROUP BY m.id, m.nickname")
+    List<MemberRankingDto> findAllMemberInfos();
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/controller/RankingController.java
@@ -31,7 +31,7 @@ public class RankingController {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }
-        RankingListResponse rankingListResponse = rankingService.lookUpPaginationRanking(offset);
+        RankingListResponse rankingListResponse = rankingService.lookUpPaginationTotalRanking(offset);
         return ResponseEntity.ok().body(rankingListResponse);
     }
 
@@ -40,14 +40,14 @@ public class RankingController {
             @RequestParam(name = "offset") Integer offset
     ) {
         if(offset == null) {
-            offset = 0;
+            offset = 1;
         }
         if(!isValidOffset(offset)) {
             // TODO: IllegalArgumentException -> Custom Exception
             throw new IllegalArgumentException("offset must be greater than zero");
         }
-
-        return ResponseEntity.ok().body(null);
+        RankingListResponse rankingListResponse = rankingService.lookUpPaginationRivalRanking(offset);
+        return ResponseEntity.ok().body(rankingListResponse);
     }
 
     private boolean isValidOffset(Integer offset) {

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
@@ -1,10 +1,36 @@
 package com.sascom.chickenstock.domain.ranking.dto;
 
-public interface MemberRankingDto {
-    Long getMemberId();
-    Integer getRanking();
-    String getNickname();
-    Long getProfit();
-    Integer getRating();
-    Integer getCompetitionCount();
+import lombok.Getter;
+
+@Getter
+public class MemberRankingDto {
+    private Long memberId;
+    private String nickname;
+    private long profit;
+    private int rating;
+    private int competitionCount;
+    private int ranking;
+
+    private MemberRankingDto() {}
+
+    public MemberRankingDto(
+            Long memberId,
+            String nickname,
+            Long profit,
+            Long rating,
+            Long competitionCount) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profit = profit == null? 0L : profit;
+        this.rating = rating == null? 0 : rating.intValue();
+        this.competitionCount = competitionCount == null? 0 : competitionCount.intValue();
+    }
+
+    public void addRating(int value) {
+        rating += value;
+    }
+
+    public void updateRanking(int ranking) {
+        this.ranking = ranking;
+    }
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/dto/MemberRankingDto.java
@@ -1,5 +1,6 @@
 package com.sascom.chickenstock.domain.ranking.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -24,6 +25,23 @@ public class MemberRankingDto {
         this.profit = profit == null? 0L : profit;
         this.rating = rating == null? 0 : rating.intValue();
         this.competitionCount = competitionCount == null? 0 : competitionCount.intValue();
+    }
+
+    @Builder
+    public MemberRankingDto(
+            Long memberId,
+            String nickname,
+            long profit,
+            int rating,
+            int competitionCount,
+            int ranking
+    ) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profit = profit;
+        this.rating = rating;
+        this.competitionCount = competitionCount;
+        this.ranking = ranking;
     }
 
     public void addRating(int value) {

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
@@ -1,43 +1,45 @@
 package com.sascom.chickenstock.domain.ranking.service;
 
-import com.sascom.chickenstock.domain.account.repository.AccountRepository;
 import com.sascom.chickenstock.domain.member.entity.Member;
 import com.sascom.chickenstock.domain.member.repository.MemberRepository;
 import com.sascom.chickenstock.domain.ranking.dto.MemberRankingDto;
 import com.sascom.chickenstock.domain.ranking.dto.response.RankingListResponse;
 import com.sascom.chickenstock.domain.ranking.util.RatingCalculatorV1;
+import com.sascom.chickenstock.domain.rival.repository.RivalRepository;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class RankingService {
     private final MemberRepository memberRepository;
-    private List<MemberRankingDto> cachedRankingList;
+    private final RivalRepository rivalRepository;
+    private List<MemberRankingDto> cachedTotalRankingList;
 
     @Autowired
-    public RankingService(MemberRepository memberRepository) {
+    public RankingService(MemberRepository memberRepository, RivalRepository rivalRepository) {
         this.memberRepository = memberRepository;
+        this.rivalRepository = rivalRepository;
     }
 
     @PostConstruct
     public void init() {
-        cachedRankingList = memberRepository.findAllMemberInfos();
-        for(int i = 0; i < cachedRankingList.size(); i++) {
-            if(cachedRankingList.get(i).getCompetitionCount() > 0) {
-                cachedRankingList.get(i).addRating(RatingCalculatorV1.INITIAL_RATING);
+        cachedTotalRankingList = memberRepository.findAllMemberInfos();
+        for(int i = 0; i < cachedTotalRankingList.size(); i++) {
+            if(cachedTotalRankingList.get(i).getCompetitionCount() > 0) {
+                cachedTotalRankingList.get(i).addRating(RatingCalculatorV1.INITIAL_RATING);
             }
         }
-        cachedRankingList.sort((lhs, rhs) -> -Integer.compare(lhs.getRating(), rhs.getRating()));
-        for(int i = 0, j = 0; i < cachedRankingList.size(); i = j) {
-            while(j < cachedRankingList.size() &&
-                    cachedRankingList.get(i).getRating() == cachedRankingList.get(j).getRating()) {
-                cachedRankingList.get(j++).updateRanking(i + 1);
+        cachedTotalRankingList.sort((lhs, rhs) -> -Integer.compare(lhs.getRating(), rhs.getRating()));
+        for(int i = 0, j = 0; i < cachedTotalRankingList.size(); i = j) {
+            while(j < cachedTotalRankingList.size() &&
+                    cachedTotalRankingList.get(i).getRating() == cachedTotalRankingList.get(j).getRating()) {
+                cachedTotalRankingList.get(j++).updateRanking(i + 1);
             }
         }
     }
@@ -50,8 +52,8 @@ public class RankingService {
 //                .build();
 //    }
 
-    public RankingListResponse lookUpPaginationRanking(int offset) {
-        if(cachedRankingList == null) {
+    public RankingListResponse lookUpPaginationTotalRanking(int offset) {
+        if(cachedTotalRankingList == null) {
             // TODO: change into ranking exception
             throw new IllegalStateException("server logic error");
         }
@@ -60,30 +62,78 @@ public class RankingService {
         int pageSize = 10;
 
         // invalid offset error
-        if(cachedRankingList.isEmpty()) {
+        if(cachedTotalRankingList.isEmpty()) {
             if(offset != 1){
+                // TODO: change into ranking exception
                 throw new IllegalArgumentException("not found");
             }
         }
         else {
-            if(offset < 0 || (long)pageSize * offset > (long)cachedRankingList.size()) {
+            if(offset <= 0 || (long)pageSize * (offset - 1) > (long) cachedTotalRankingList.size()) {
+                // TODO: change into ranking exception
                 throw new IllegalArgumentException("not found");
             }
         }
 
+        return getRankingListResponse(cachedTotalRankingList, pageSize, offset);
+    }
+
+    public RankingListResponse lookUpPaginationRivalRanking(int offset) {
+        // TODO: context holder에서 member 조회해오는 걸로 수정
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new IllegalStateException("Authorization error"));
+
+        Set<Long> rivals = rivalRepository.findByMemberId(member.getId())
+                .stream()
+                .map(rival -> rival.getEnemy().getId())
+                .collect(Collectors.toUnmodifiableSet());
+        List<MemberRankingDto> rivalRankingList = cachedTotalRankingList.stream()
+                .filter(memberRankingDto ->
+                        rivals.contains(memberRankingDto.getMemberId())
+                                || memberRankingDto.getMemberId().equals(member.getId())
+                )
+                .map(memberRankingDto -> MemberRankingDto.builder()
+                        .memberId(memberRankingDto.getMemberId())
+                        .nickname(memberRankingDto.getNickname())
+                        .profit(memberRankingDto.getProfit())
+                        .rating(memberRankingDto.getRating())
+                        .competitionCount(memberRankingDto.getCompetitionCount())
+                        .ranking(memberRankingDto.getRanking())
+                        .build()
+                )
+                .toList();
+        if(rivalRankingList.isEmpty()) {
+            // TODO: change into ranking exception
+            throw new IllegalStateException("server logic error");
+        }
+
+        int pageSize = 10;
+        if(offset <= 0 || (long)pageSize * (offset - 1) > (long) rivalRankingList.size()) {
+            // TODO: change into ranking exception
+            throw new IllegalArgumentException("not found");
+        }
+        return getRankingListResponse(rivalRankingList, pageSize, offset);
+    }
+
+    private RankingListResponse getRankingListResponse(List<MemberRankingDto> RankingList, int pageSize, int offset) {
         return RankingListResponse.builder()
                 .memberList(
-                        cachedRankingList.subList(pageSize * (offset - 1), Math.min(cachedRankingList.size(), pageSize * offset))
+                        RankingList
+                                .subList(
+                                        pageSize * (offset - 1),
+                                        Math.min(RankingList.size(), pageSize * offset)
+                                )
                                 .stream()
-                                .map((memberRankingDto) -> MemberRankingDto.builder()
+                                .map(memberRankingDto -> MemberRankingDto.builder()
                                         .memberId(memberRankingDto.getMemberId())
                                         .nickname(memberRankingDto.getNickname())
+                                        .profit(memberRankingDto.getProfit())
                                         .rating(memberRankingDto.getRating())
                                         .competitionCount(memberRankingDto.getCompetitionCount())
                                         .ranking(memberRankingDto.getRanking())
                                         .build()
                                 )
-                                .collect(Collectors.toList())
+                                .toList()
                 )
                 .build();
     }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/service/RankingService.java
@@ -13,14 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class RankingService {
-    // 분명 rival 랭킹과 전체 랭킹을 한 번에 처리할 수 있게 짤 수 있을 거 같다...
-    // + 전체 유저가 적은데 저걸 매번 DB에서 복잡한 쿼리를 날려서 받아올게 아니라 여기에 List 형태로
-    //   memoryRepository로 저장해두고 대회 끝날 때 마다 레이팅 계산하고 update 하면 되지 않나...?
     private final MemberRepository memberRepository;
     private List<MemberRankingDto> cachedRankingList;
+
+    @Autowired
+    public RankingService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     @PostConstruct
     public void init() {
@@ -39,16 +42,49 @@ public class RankingService {
         }
     }
 
-    @Autowired
-    public RankingService(MemberRepository memberRepository, AccountRepository accountRepository) {
-        this.memberRepository = memberRepository;
-    }
+//    @Transactional(readOnly = true)
+//    public RankingListResponse lookUpPaginationRanking(int offset) {
+//        List<MemberRankingDto> result = memberRepository.test((offset - 1) * 10);
+//        return RankingListResponse.builder()
+//                .memberList(result)
+//                .build();
+//    }
 
-    @Transactional(readOnly = true)
     public RankingListResponse lookUpPaginationRanking(int offset) {
-        List<MemberRankingDto> result = memberRepository.test((offset - 1) * 10);
+        if(cachedRankingList == null) {
+            // TODO: change into ranking exception
+            throw new IllegalStateException("server logic error");
+        }
+
+        // later, pageSize can be parameter passed from request.
+        int pageSize = 10;
+
+        // invalid offset error
+        if(cachedRankingList.isEmpty()) {
+            if(offset != 1){
+                throw new IllegalArgumentException("not found");
+            }
+        }
+        else {
+            if(offset < 0 || (long)pageSize * offset > (long)cachedRankingList.size()) {
+                throw new IllegalArgumentException("not found");
+            }
+        }
+
         return RankingListResponse.builder()
-                .memberList(result)
+                .memberList(
+                        cachedRankingList.subList(pageSize * (offset - 1), Math.min(cachedRankingList.size(), pageSize * offset))
+                                .stream()
+                                .map((memberRankingDto) -> MemberRankingDto.builder()
+                                        .memberId(memberRankingDto.getMemberId())
+                                        .nickname(memberRankingDto.getNickname())
+                                        .rating(memberRankingDto.getRating())
+                                        .competitionCount(memberRankingDto.getCompetitionCount())
+                                        .ranking(memberRankingDto.getRanking())
+                                        .build()
+                                )
+                                .collect(Collectors.toList())
+                )
                 .build();
     }
 }

--- a/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
+++ b/src/main/java/com/sascom/chickenstock/domain/ranking/util/RatingCalculatorV1.java
@@ -9,7 +9,7 @@ reference: [Codeforces Rating System](https://codeforces.com/blog/entry/20762)
  */
 public class RatingCalculatorV1 {
 
-    static final int INITIAL_RATING = 1200;
+    public static final int INITIAL_RATING = 1200;
     private final int RATING_LOWER_BOUND = 0;
     private final int RATING_UPPER_BOUND = 5000;
 

--- a/src/main/java/com/sascom/chickenstock/domain/rival/repository/RivalRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/rival/repository/RivalRepository.java
@@ -1,7 +1,12 @@
 package com.sascom.chickenstock.domain.rival.repository;
 
+import com.sascom.chickenstock.domain.member.entity.Member;
 import com.sascom.chickenstock.domain.rival.entity.Rival;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface RivalRepository extends JpaRepository<Rival, Long> {
+    List<Rival> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
resolve #37 
-------------------------------------------
## 개요
전체 랭킹 조회에 이어 rival 랭킹 조회를 구현했습니다.
전체 랭킹 조회에서 순위를 조회할 때 매번 DB에 요청을 보냈고,
DB에 요청을 보낼 때 MySQL에 의존적으로 native query를 이용해서 작성했습니다.
전체 사용자를 우선 1,000명으로 잡았다면 ranking에 대한 정보를 메모리에 들고 있어도 될 것이라 생각했고
지금 DB인 MySQL과 의존성을 떨어뜨린 jpql로만 작성을 해서 메모리에 가져오고,
순위는 가져온 뒤 정렬을 해서 계산하게 수정했습니다.
rival 랭킹 조회도 rival만 가져와서 memory에서 해결했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

!테스트 사진 첨부!
