### PR TITLE
[#68] FcmToken 저장 로직 구현

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/fcmtoken/controller/FcmTokenController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/fcmtoken/controller/FcmTokenController.java
@@ -1,0 +1,50 @@
+package com.sascom.chickenstock.domain.fcmtoken.controller;
+
+import com.sascom.chickenstock.domain.fcmtoken.dto.request.FcmTokenRequest;
+import com.sascom.chickenstock.domain.fcmtoken.dto.response.FcmTokenResponse;
+import com.sascom.chickenstock.domain.fcmtoken.entity.FcmToken;
+import com.sascom.chickenstock.domain.fcmtoken.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/fcm")
+@RequiredArgsConstructor
+public class FcmTokenController {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @PostMapping
+    public ResponseEntity<FcmTokenResponse> saveFcmToken(@RequestBody FcmTokenRequest request) {
+        // memberId로 FCM 토큰 엔티티를 조회
+        Optional<FcmToken> existingFcmToken = fcmTokenRepository.findByMemberId(request.memberId());
+
+        if (existingFcmToken.isPresent()) {
+            // 존재하는 경우 토큰만 업데이트
+            FcmToken fcmToken = existingFcmToken.get();
+            fcmToken.setToken(request.fcmToken());
+            // fcmTokenRepository.save(fcmToken);
+
+        } else {
+            // 존재하지 않는 경우 새로운 엔티티 생성 후 저장
+            FcmToken newFcmToken = new FcmToken();
+            newFcmToken.setMemberId(request.memberId());
+            newFcmToken.setToken(request.fcmToken());
+            fcmTokenRepository.save(newFcmToken);
+        }
+
+        return ResponseEntity.ok().body(
+                FcmTokenResponse.builder()
+                        .message("Success to Save FcmToken")
+                        .fcmToken(request.fcmToken())
+                        .memberId(request.memberId())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/sascom/chickenstock/domain/fcmtoken/dto/request/FcmTokenRequest.java
+++ b/src/main/java/com/sascom/chickenstock/domain/fcmtoken/dto/request/FcmTokenRequest.java
@@ -1,0 +1,7 @@
+package com.sascom.chickenstock.domain.fcmtoken.dto.request;
+
+public record FcmTokenRequest (
+        Long memberId,
+        String fcmToken
+) {
+}

--- a/src/main/java/com/sascom/chickenstock/domain/fcmtoken/dto/response/FcmTokenResponse.java
+++ b/src/main/java/com/sascom/chickenstock/domain/fcmtoken/dto/response/FcmTokenResponse.java
@@ -1,0 +1,11 @@
+package com.sascom.chickenstock.domain.fcmtoken.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record FcmTokenResponse (
+        Long memberId,
+        String fcmToken,
+        String message
+) {
+}

--- a/src/main/java/com/sascom/chickenstock/domain/fcmtoken/entity/FcmToken.java
+++ b/src/main/java/com/sascom/chickenstock/domain/fcmtoken/entity/FcmToken.java
@@ -1,0 +1,19 @@
+package com.sascom.chickenstock.domain.fcmtoken.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+public class FcmToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long memberId;
+    private String token;
+}

--- a/src/main/java/com/sascom/chickenstock/domain/fcmtoken/repository/FcmTokenRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/fcmtoken/repository/FcmTokenRepository.java
@@ -1,0 +1,10 @@
+package com.sascom.chickenstock.domain.fcmtoken.repository;
+
+import com.sascom.chickenstock.domain.fcmtoken.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    Optional<FcmToken> findByMemberId(Long memberId);
+}


### PR DESCRIPTION
- resolve #68 
-------------------------------------------
## 개요

로그인한 memberId과 fcmToken을 저장하는 로직입니다.
로그인 성공시 FcmTokenController의 POST 요청으로 저장하는거 프론트에서 추가하면 될듯합니다.


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

!테스트 사진 첨부!
