### PR TITLE
[#73] - 대회 참여 히스토리 API 수정

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/competition/dto/response/CompetitionListResponse.java
+++ b/src/main/java/com/sascom/chickenstock/domain/competition/dto/response/CompetitionListResponse.java
@@ -12,6 +12,7 @@ public record CompetitionListResponse(
         LocalDateTime endAt,
         Integer rank,
         Integer ratingChange,
-        Long balance
+        Long balance,
+        Long accountId
 ) {
 }

--- a/src/main/java/com/sascom/chickenstock/domain/competition/service/CompetitionService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/competition/service/CompetitionService.java
@@ -54,6 +54,7 @@ public class CompetitionService {
                     .rank(account.getRanking())
                     .ratingChange(account.getRatingChange())
                     .balance(account.getBalance())
+                    .accountId(account.getId())
                     .build()
             );
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,10 +14,10 @@ spring:
       hibernate:
         format_sql: true
     defer-datasource-initialization: true
-  sql:
-    init:
-      mode: always
-      show_sql: true
+#  sql:
+#    init:
+#      mode: always
+#      show_sql: true
 
 websocket:
   url: ${SOCKET_URL}


### PR DESCRIPTION
 resolve #73 
-------------------------------------------
## 개요
대회 참여 히스토리 response에 account_id를 넣어야 함
그래야 해당 대회를 눌렀을 때 그 대회의 매매 내역 히스토리(원장)을 볼 수 있기 때문
for axios 연결

## PR 유형
어떤 변경 사항이 있나요?

- [x] 기능 수정

