### PR TITLE
[#80] - 로그인 시 competition이 없을경우 에러 발생 수정

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/account/service/AccountService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/account/service/AccountService.java
@@ -319,20 +319,17 @@ public class AccountService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MemberNotFoundException.of(MemberErrorCode.NOT_FOUND));
         Account account = accountRepository.findTopByMemberOrderByIdDesc(member);
+
         // 최신 계좌 조회해서 거기에 있는 CompetitonId가 현재의 대회 pk랑 같은지 체크
         Competition competition = competitionRepository.findTopByAccountsOrderByIdDesc(account);
         LocalDateTime now = LocalDateTime.now();
-        boolean isCompParticipant = false;
-        if (competition.getStartAt().isBefore(now) && competition.getEndAt().isAfter(now)) { // 지금 열리고 있는 대회
-            isCompParticipant = true;
+
+        if (competition != null &&
+                competition.getStartAt().isBefore(now) && competition.getEndAt().isAfter(now)) { // 지금 열리고 있는 대회
+            return AccountInfoForLogin.create(true, account.getBalance(), account.getRanking());
         }
-        AccountInfoForLogin accountInfoForLogin;
-        if (isCompParticipant && Objects.equals(account.getCompetition().getId(), competition.getId())) {
-            accountInfoForLogin = AccountInfoForLogin.create(isCompParticipant, account.getBalance(), account.getRanking());
-        } else {
-            accountInfoForLogin = AccountInfoForLogin.create(isCompParticipant, 0L, 0);
-        }
-        return accountInfoForLogin;
+
+        return AccountInfoForLogin.create(false, 0L, 0);
     }
 
     private Member validateMember(Long memberId) {


### PR DESCRIPTION
- resolve: #80 
-------------------------------------------
## 개요
- 조건문에 not null을 추가하여 null exception 방지.
- 중복된 로직 제거

## PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 코드 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
