### PR TITLE
[#89] 프로필 이미지 업데이트시 response 수정

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/controller/MemberController.java
@@ -64,9 +64,9 @@ public class MemberController {
     }
 
     @PostMapping(value = "/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> postImage(@RequestParam("file") MultipartFile file) {
-        memberService.setImage(file);
-        return ResponseEntity.ok().body("프로필 이미지 업로드 완료");
+    public ResponseEntity<Map<String, String>> postImage(@RequestParam("file") MultipartFile file) {
+        String changedUrl = memberService.setImage(file);
+        return ResponseEntity.ok().body(Map.of("imgUrl", changedUrl));
     }
 
     @GetMapping(value = "/img/{userId}", produces = {MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE})

--- a/src/main/java/com/sascom/chickenstock/domain/member/service/MemberService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/service/MemberService.java
@@ -176,7 +176,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void setImage(MultipartFile file) {
+    public String setImage(MultipartFile file) {
         Member member = memberRepository.findById(SecurityUtil.getCurrentMemberId())
                 .orElseThrow(() -> MemberNotFoundException.of(MemberErrorCode.NOT_FOUND));
         if(file.isEmpty()) {
@@ -186,7 +186,13 @@ public class MemberService {
         byte[] fileBytes = null;
         String extension = null;
         try {
-            extension = getFileExtension(file, fileBytes);
+            fileBytes = file.getBytes();
+            if (MagicNumbers.JPG.is(fileBytes)) {
+                extension = "jpg";
+            }
+            else if (MagicNumbers.PNG.is(fileBytes)) {
+                extension = "png";
+            }
         } catch(IOException e) {
             throw MemberImageException.of(MemberErrorCode.IO_ERROR);
         }
@@ -205,6 +211,7 @@ public class MemberService {
         } catch(IOException e) {
             throw MemberImageException.of(MemberErrorCode.IO_ERROR);
         }
+        return imgUrl + fileName;
     }
 
     public byte[] getImage(Long id) {
@@ -227,18 +234,6 @@ public class MemberService {
                 .orElseThrow(() -> MemberNotFoundException.of(MemberErrorCode.NOT_FOUND));
         member.updateImgName(defaultImgName);
         memberRepository.save(member);
-    }
-
-    private String getFileExtension(MultipartFile file, byte[] fileBytes) throws IOException {
-        String extension = null;
-        fileBytes = file.getBytes();
-        if (MagicNumbers.JPG.is(fileBytes)) {
-            extension = "jpg";
-        }
-        else if (MagicNumbers.PNG.is(fileBytes)) {
-            extension = "png";
-        }
-        return extension;
     }
 
     private void saveFile(byte[] fileBytes, String fileName, String extension) throws IOException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
       hibernate:
         format_sql: true
     defer-datasource-initialization: true
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
 #  sql:
 #    init:
 #      mode: always


### PR DESCRIPTION
# 제목 
[이슈번호] 이슈 제목
-------------------------------------------
## 개요
현재는 프로필 이미지 업데이트가 성공했을 때 "프로필 이미지 업로드 완료" 문자열만 보냈으나, 요구 사항이 변경되어 수정했습니다.
추가로 이미지 업데이트의 파일 처리 부분에 문제가 있는 것을 발견하여 이 부분도 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정
- [x] 코드 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

!테스트 사진 첨부!
