### PR TITLE
[#106] 카카오 유저 load 시 response outputstream write 에러 해결

### DIFF
--- a/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
@@ -4,18 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sascom.chickenstock.domain.auth.dto.response.ResponseLoginMember;
 import com.sascom.chickenstock.domain.member.service.MemberFacade;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 @Component
 class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
@@ -36,14 +36,15 @@ class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     }
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         response.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         ResponseLoginMember memberInfoForLogin = memberFacade.getLoginInfo(response, authentication);
-        try(ServletOutputStream os = response.getOutputStream()) {
+        try(PrintWriter pw = response.getWriter()) {
             String body = objectMapper.writeValueAsString(memberInfoForLogin);
-            os.print(body);
-            os.flush();
+            pw.write(body);
+            pw.flush();
         }
         response.setStatus(HttpServletResponse.SC_OK);
     }


### PR DESCRIPTION
- resolve: #106 
-------------------------------------------
## 개요
- response char encoding 설정
- outputstream -> printwriter로 변경

## PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).