### PR TITLE
[#113] 유저 정보 반환 api 추가

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/controller/MemberController.java
@@ -1,13 +1,18 @@
 package com.sascom.chickenstock.domain.member.controller;
 
+import com.sascom.chickenstock.domain.auth.dto.response.ResponseLoginMember;
 import com.sascom.chickenstock.domain.member.dto.request.ChangePasswordRequest;
 import com.sascom.chickenstock.domain.member.dto.request.ChangeNicknameRequest;
 import com.sascom.chickenstock.domain.member.dto.response.MemberInfoResponse;
 import com.sascom.chickenstock.domain.member.dto.response.PrefixNicknameInfosResponse;
+import com.sascom.chickenstock.domain.member.service.MemberFacade;
 import com.sascom.chickenstock.domain.member.service.MemberService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -19,16 +24,25 @@ import java.util.Map;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberFacade memberFacade;
 
     @Autowired
-    public MemberController(MemberService memberService) {
+    public MemberController(MemberService memberService, MemberFacade memberFacade) {
         this.memberService = memberService;
+        this.memberFacade = memberFacade;
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<MemberInfoResponse> getMemberInfo(@PathVariable("userId") Long userId) {
         MemberInfoResponse response = memberService.lookUpMemberInfo(userId);
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseLoginMember> getMemberInfo(HttpServletResponse response) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        ResponseLoginMember loginInfo = memberFacade.getLoginInfo(response, authentication);
+        return ResponseEntity.ok(loginInfo);
     }
 
     @PostMapping

--- a/src/main/java/com/sascom/chickenstock/domain/member/service/MemberFacade.java
+++ b/src/main/java/com/sascom/chickenstock/domain/member/service/MemberFacade.java
@@ -2,20 +2,13 @@ package com.sascom.chickenstock.domain.member.service;
 
 import com.sascom.chickenstock.domain.account.service.AccountService;
 import com.sascom.chickenstock.domain.account.service.RedisService;
-import com.sascom.chickenstock.domain.auth.dto.request.RequestLoginMember;
 import com.sascom.chickenstock.domain.auth.dto.response.AccountInfoForLogin;
 import com.sascom.chickenstock.domain.auth.dto.response.ResponseLoginMember;
 import com.sascom.chickenstock.domain.member.dto.MemberInfoForLogin;
-import com.sascom.chickenstock.global.jwt.JwtProperties;
 import com.sascom.chickenstock.global.jwt.JwtProvider;
+import com.sascom.chickenstock.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.DependsOn;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -25,30 +18,23 @@ import java.time.LocalDateTime;
 public class MemberFacade {
     private final MemberService memberService;
     private final AccountService accountService;
-//    private final AuthenticationManager authenticationManager;
-    private final JwtProperties jwtProperties;
     private final JwtProvider jwtProvider;
     private final RedisService redisService;
 
-    private final boolean COOKIE_HTTP_ONLY = true;
-    @Value("${chicken-stock.domain}")
-    private String COOKIE_DOMAIN;
-    @Value("${jwt.cookie-path}")
-    private String COOKIE_PATH;
-    private final String COOKIE_SAME_SITE = "NONE";
-    private final boolean COOKIE_SECURE = true;
+    private final CookieUtil cookieUtil;
 
     @Autowired
     public MemberFacade(
-            MemberService memberService, AccountService accountService,
-            JwtProperties jwtProperties, JwtProvider jwtProvider,
-            RedisService redisService
-    ) {
+            MemberService memberService,
+            AccountService accountService,
+            JwtProvider jwtProvider,
+            RedisService redisService,
+            CookieUtil cookieUtil) {
         this.memberService = memberService;
         this.accountService = accountService;
-        this.jwtProperties = jwtProperties;
         this.jwtProvider = jwtProvider;
         this.redisService = redisService;
+        this.cookieUtil = cookieUtil;
     }
 
     public ResponseLoginMember getLoginInfo(HttpServletResponse response, Authentication authentication) {
@@ -60,33 +46,10 @@ public class MemberFacade {
         String accessToken = jwtProvider.createToken(authentication, jwtProvider.getAccessTokenExpirationDate());
         LocalDateTime refreshTokenExpirationDate = jwtProvider.getRefreshTokenExpirationDate();
         String refreshToken = jwtProvider.createToken(authentication, refreshTokenExpirationDate);
-
-        setJwtTokensInCookie(response, accessToken, refreshToken);
-
         redisService.setValues(authentication.getName(), refreshToken, refreshTokenExpirationDate);
 
+        cookieUtil.setAuthTokenCookie(accessToken, refreshToken, response);
+
         return new ResponseLoginMember(memberInfoForLogin, accountInfoForLogin);
-    }
-
-    private void setJwtTokensInCookie(HttpServletResponse response, String accessToken, String refreshToken) {
-        ResponseCookie accessTokenCookie = ResponseCookie.from(jwtProperties.accessToken().cookieName(), accessToken)
-                .httpOnly(COOKIE_HTTP_ONLY)
-                .domain(COOKIE_DOMAIN)
-                .path(COOKIE_PATH)
-                .sameSite(COOKIE_SAME_SITE)
-                .secure(COOKIE_SECURE)
-                .build();
-        ResponseCookie refreshTokenCookie = ResponseCookie.from(jwtProperties.refreshToken().cookieName(), refreshToken)
-                .httpOnly(COOKIE_HTTP_ONLY)
-                .domain(COOKIE_DOMAIN)
-                .path(COOKIE_PATH)
-                .sameSite(COOKIE_SAME_SITE)
-                .secure(COOKIE_SECURE)
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        response.setStatus(HttpServletResponse.SC_OK);
     }
 }

--- a/src/main/java/com/sascom/chickenstock/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sascom/chickenstock/global/filter/JwtAuthenticationFilter.java
@@ -25,6 +25,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -70,8 +71,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 //            }
 //
 //            // 블랙리스트에 올라간 Access Token 검증
-//            String isLogout = String.valueOf(redisService.getValues(accessToken));
-//            if(ObjectUtils.isEmpty(isLogout)) {
+//            Optional<String> blacklistToken = redisService.getValues(accessToken);
+//            if(blacklistToken.isEmpty()) {
 //                Authentication authentication = jwtResolver.getAuthentication(accessToken);
 //                SecurityContextHolder.getContext().setAuthentication(authentication);
 //            }

--- a/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.sascom.chickenstock.global.oauth.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sascom.chickenstock.domain.auth.dto.response.ResponseLoginMember;
 import com.sascom.chickenstock.domain.member.service.MemberFacade;
+import com.sascom.chickenstock.global.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,32 +21,22 @@ import java.nio.charset.StandardCharsets;
 @Component
 class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    public static final String KAKAO_LOGIN = "/kakaoLogin";
     private final String BASE_URI;
     private final MemberFacade memberFacade;
-    private final ObjectMapper objectMapper;
 
     @Autowired
     public OAuth2SuccessHandler(
             @Value("${oauth.base-uri}") String baseUri,
-            MemberFacade memberFacade,
-            ObjectMapper objectMapper
+            MemberFacade memberFacade
     ) {
         this.BASE_URI = baseUri;
         this.memberFacade = memberFacade;
-        this.objectMapper = objectMapper;
     }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        response.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        ResponseLoginMember memberInfoForLogin = memberFacade.getLoginInfo(response, authentication);
-        try(PrintWriter pw = response.getWriter()) {
-            String body = objectMapper.writeValueAsString(memberInfoForLogin);
-            pw.write(body);
-            pw.flush();
-        }
-        response.setStatus(HttpServletResponse.SC_OK);
+        memberFacade.getLoginInfo(response, authentication);
+        response.sendRedirect(BASE_URI + KAKAO_LOGIN);
     }
 }

--- a/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sascom/chickenstock/global/oauth/handler/OAuth2SuccessHandler.java
@@ -1,27 +1,20 @@
 package com.sascom.chickenstock.global.oauth.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sascom.chickenstock.domain.auth.dto.response.ResponseLoginMember;
 import com.sascom.chickenstock.domain.member.service.MemberFacade;
-import com.sascom.chickenstock.global.jwt.JwtProvider;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 
 @Component
 class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    public static final String KAKAO_LOGIN = "/kakaoLogin";
+    public static final String KAKAO_LOGIN_SUFFIX = "/kakaoLogin";
     private final String BASE_URI;
     private final MemberFacade memberFacade;
 
@@ -37,6 +30,6 @@ class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         memberFacade.getLoginInfo(response, authentication);
-        response.sendRedirect(BASE_URI + KAKAO_LOGIN);
+        response.sendRedirect(BASE_URI + KAKAO_LOGIN_SUFFIX);
     }
 }

--- a/src/main/java/com/sascom/chickenstock/global/util/CookieUtil.java
+++ b/src/main/java/com/sascom/chickenstock/global/util/CookieUtil.java
@@ -1,0 +1,53 @@
+package com.sascom.chickenstock.global.util;
+
+import com.sascom.chickenstock.global.jwt.JwtProperties;
+import com.sascom.chickenstock.global.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class CookieUtil {
+
+    private final boolean COOKIE_HTTP_ONLY = true;
+    private final JwtProperties jwtProperties;
+    @Value("${chicken-stock.domain}")
+    private String COOKIE_DOMAIN;
+    @Value("${jwt.cookie-path}")
+    private String COOKIE_PATH;
+    private final String COOKIE_SAME_SITE = "NONE";
+    private final boolean COOKIE_SECURE = true;
+
+    public CookieUtil(JwtProperties jwtProperties, JwtProvider jwtProvider) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    public void setAuthTokenCookie(String accessToken, String refreshToken, HttpServletResponse response) {
+        ResponseCookie accessTokenCookie = createCookie(jwtProperties.accessToken().cookieName(), accessToken);
+        ResponseCookie refreshTokenCookie = createCookie(jwtProperties.refreshToken().cookieName(), refreshToken);
+
+        setCookie(accessTokenCookie, response);
+        setCookie(refreshTokenCookie, response);
+    }
+
+    public void setCookie(HttpCookie cookie, HttpServletResponse response) {
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public ResponseCookie createCookie(String name, String value) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(COOKIE_HTTP_ONLY)
+                .domain(COOKIE_DOMAIN)
+                .path(COOKIE_PATH)
+                .sameSite(COOKIE_SAME_SITE)
+                .secure(COOKIE_SECURE)
+                .build();
+
+    }
+}


### PR DESCRIPTION
- resolve: #113 
-------------------------------------------
## 개요
oauth로그인 시 기존 로직으로는 클라이언트가 member 정보를 받을 수 없음.
따라서 member의 정보를 반환할 수 있는 api를 생성 후, 호출하여 클라이언트에서 정보 수신.

+ 현재 주석 처리되어 있는 jwt filter 버그 수정, cookie 생성 및 추가 부분을 cookie util로 분리

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).