### PR TITLE
[#124] 서버 가동시 시장가가 비어있는 문제 수정

### DIFF
--- a/src/main/java/com/sascom/chickenstock/domain/dailystockprice/error/code/DailyStockPriceErrorCode.java
+++ b/src/main/java/com/sascom/chickenstock/domain/dailystockprice/error/code/DailyStockPriceErrorCode.java
@@ -13,7 +13,7 @@ public enum DailyStockPriceErrorCode implements ChickenStockErrorCode {
 
     DailyStockPriceErrorCode(HttpStatus status, String code, String message) {
         this.status = status;
-        this.code = "RIVAL"+code;
+        this.code = "STOCKPRICE"+code;
         this.message = message;
     }
 

--- a/src/main/java/com/sascom/chickenstock/domain/dailystockprice/repository/DailyStockPriceRepository.java
+++ b/src/main/java/com/sascom/chickenstock/domain/dailystockprice/repository/DailyStockPriceRepository.java
@@ -2,6 +2,8 @@ package com.sascom.chickenstock.domain.dailystockprice.repository;
 
 import com.sascom.chickenstock.domain.dailystockprice.entity.DailyStockPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,4 +12,6 @@ import java.util.Optional;
 public interface DailyStockPriceRepository extends JpaRepository<DailyStockPrice, Long> {
     List<DailyStockPrice> findDailyStockPriceByCompanyId(Long companyId);
     Optional<DailyStockPrice> findDailyStockPriceByDateTimeAndCompanyId(LocalDate localDate, Long companyId);
+
+    Optional<DailyStockPrice> findFirstByCompanyIdOrderByDateTimeDesc(Long companyId);
 }

--- a/src/main/java/com/sascom/chickenstock/domain/dailystockprice/service/DailyStockPriceService.java
+++ b/src/main/java/com/sascom/chickenstock/domain/dailystockprice/service/DailyStockPriceService.java
@@ -1,6 +1,8 @@
 package com.sascom.chickenstock.domain.dailystockprice.service;
 
 import com.sascom.chickenstock.domain.company.entity.Company;
+import com.sascom.chickenstock.domain.company.error.code.CompanyErrorCode;
+import com.sascom.chickenstock.domain.company.error.exception.CompanyNotFoundException;
 import com.sascom.chickenstock.domain.company.repository.CompanyRepository;
 import com.sascom.chickenstock.domain.dailystockprice.dto.request.fis.AccessTokenReqeust;
 import com.sascom.chickenstock.domain.dailystockprice.dto.response.DailyStockPriceResponse;
@@ -50,6 +52,12 @@ public class DailyStockPriceService {
                 .toList();
 
         return dailyStockPriceResponseList;
+    }
+
+    public Long getLatestClosingPriceByCompanyId(Long companyId) {
+        DailyStockPrice dailyStockPrice = dailyStockPriceRepository.findFirstByCompanyIdOrderByDateTimeDesc(companyId)
+                .orElseThrow(() -> CompanyNotFoundException.of(CompanyErrorCode.NOT_FOUND));
+        return dailyStockPrice.getClosingPrice();
     }
 
     // 매일 18시에 실행


### PR DESCRIPTION
resolve #124 
-------------------------------------------
## 개요
시장가는 TradeService에서 @PostConstruct를 이용해 넣어주고 있는데, 이전까지는 정보가 없어 임시로 값을 넣고 실행했습니다.
현재 전날 종가 정보가 생겨 불러올 수 있게 되어 수정하였습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
